### PR TITLE
IE8 support

### DIFF
--- a/hanzenkaku.js
+++ b/hanzenkaku.js
@@ -204,7 +204,7 @@
     /*
      * Extend String.prototype iff ES5 is available
      */
-    if (typeof (Object.defineProperty) === 'function')(function (obj, meth) {
+    if (typeof (Object.defineProperty) === 'function' && Object.defineProperties)(function (obj, meth) {
         var f2m = function (f) {
             return function () {
                 return f(this);


### PR DESCRIPTION
In Internet Explorer 8 Object.defineProperty only accepts DOM objects

refs.
http://kangax.github.io/es5-compat-table/#define-property-ie-note
http://msdn.microsoft.com/ja-jp/library/ff800817(v=vs.94).aspx
